### PR TITLE
Added a new option 'remove_unknown_properties'

### DIFF
--- a/validictory/__init__.py
+++ b/validictory/__init__.py
@@ -11,7 +11,8 @@ __version__ = '1.0.0'
 def validate(data, schema, validator_cls=SchemaValidator,
              format_validators=None, required_by_default=True,
              blank_by_default=False, disallow_unknown_properties=False,
-             apply_default_to_data=False, fail_fast=True):
+             apply_default_to_data=False, fail_fast=True,
+             remove_unknown_properties=False):
     '''
     Validates a parsed json document against the provided schema. If an
     error is found a :class:`ValidationError` is raised.
@@ -32,9 +33,13 @@ def validate(data, schema, validator_cls=SchemaValidator,
         data in case the schema definition includes a "default" property
     :param fail_fast: defaults to True, set to False if you prefer to get
         all validation errors back instead of only the first one
+    :param remove_unknown_properties: defaults to False, set to True to
+        filter out properties not listed in the schema definition. Only applies
+        when disallow_unknown_properties is False.
     '''
     v = validator_cls(format_validators, required_by_default, blank_by_default,
-                      disallow_unknown_properties, apply_default_to_data, fail_fast)
+                      disallow_unknown_properties, apply_default_to_data, fail_fast,
+                      remove_unknown_properties)
     return v.validate(data, schema)
 
 if __name__ == '__main__':

--- a/validictory/tests/test_remove_unknown_properties.py
+++ b/validictory/tests/test_remove_unknown_properties.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+
+import validictory
+from copy import deepcopy
+
+
+class TestRemoveUnknownProperties(TestCase):
+
+    def setUp(self):
+        self.data_simple = {"name": "john doe", "age": 42}
+        self.schema_simple = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"}
+            },
+        }
+
+        self.data_complex = {
+            "inv_number": "123",
+            "rows": [
+                {
+                    "sku": "ab-456",
+                    "desc": "a description",
+                    "price": 100.45
+                },
+                {
+                    "sku": "xy-123",
+                    "desc": "another description",
+                    "price": 999.00
+                }
+            ]
+        }
+        self.schema_complex = {
+            "type": "object",
+            "properties": {
+                "inv_number": {"type": "string"},
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "sku": {"type": "string"},
+                            "desc": {"type": "string"},
+                            "price": {"type": "number"}
+                        }
+                    },
+                }
+            }
+        }
+
+    def test_remove_unknown_properties_pass(self):
+        extra_data = deepcopy(self.data_simple)
+        extra_data["sex"] = "male"
+        validictory.validate(extra_data, self.schema_simple,
+                             remove_unknown_properties=True)
+        self.assertEqual(extra_data, self.data_simple)
+
+    def test_remove_unknown_properties_complex_pass(self):
+        try:
+            validictory.validate(self.data_complex, self.schema_complex,
+                                 remove_unknown_properties=True)
+        except ValueError as e:
+            self.fail("Unexpected failure: %s" % e)
+
+    def test_remove_unknown_properties_complex_fail(self):
+        extra_data = deepcopy(self.data_complex)
+        newrow_invalid = {"sku": "789", "desc": "catch me if you can", "price": 1,
+                  "rice": 666}
+        newrow_valid = {"sku": "789", "desc": "catch me if you can", "price": 1}
+
+        extra_data["rows"].append(newrow_invalid)
+        validictory.validate(extra_data, self.schema_complex,
+                             remove_unknown_properties=True)
+        self.data_complex["rows"].append(newrow_valid)
+        self.assertEqual(extra_data, self.data_complex)


### PR DESCRIPTION
, which simply removes fields that are not in the schema (and does so recursively). Also a new test for this feature.

If both `disallow_unknown_properties` and `remove_unknown_properties` are given the former takes precedence and a SchemaError is thrown if unknown properties are present.