### PR TITLE
fixed fail_fast behavior for typ lists

### DIFF
--- a/validictory/validator.py
+++ b/validictory/validator.py
@@ -223,7 +223,15 @@ class SchemaValidator(object):
                 errorlist = []
                 for eachtype in fieldtype:
                     try:
+                        # if fail_fast is False, _error will not rais an exception.
+                        # need to monitor the _errors list as well
+                        errors = self._errors[:]
                         self.validate_type(x, fieldname, eachtype, path, eachtype)
+                        if len(self._errors) > len(errors):
+                          # an exception was raised.
+                          # remove the error from self.errors and raise it here
+                          raise self._errors.pop()
+
                         datavalid = True
                         break
                     except ValidationError as err:


### PR DESCRIPTION
if a type is specified as a list, then the data should be validated
against each element in the list and be considered valid if item
succeeds. the validate_type function does this by catching exceptions
with a try/except block until one schema validates.

however, if fast_fail is turned off, then exceptions are not thrown
immediatly, they are instead placed in a list to be thrown later. this
caused the loop through possible schemas to exit after the first schema,
even if it was not valide. however, the first schema would still put an
error in the _errors list if it was not valid.

so, if the first schema raised an exception, its exception would be
placed in the esception list and the types loop would not catch it,
exiting immediatly. then, even if a valid schema did exist at some point
later in the list, the validate function would report an error.

this fix monitors the _errors list to handle the above situation
correctly.